### PR TITLE
Restrict the scope of a pylint decoration

### DIFF
--- a/src/dbus_client_gen/_managed_objects.py
+++ b/src/dbus_client_gen/_managed_objects.py
@@ -63,8 +63,8 @@ def managed_object_builder(spec):
                 """
                 The property getter.
                 """
-                # pylint: disable=protected-access
                 try:
+                    # pylint: disable=protected-access
                     return self._table[interface_name][name]
                 # initializer ensures that interface name is in table and
                 # name must be in table for interface because it was derived


### PR DESCRIPTION
This way, it only modifies the exact line that triggers the pylint warning.

Signed-off-by: mulhern <amulhern@redhat.com>