### PR TITLE
Allow to specify min, max child elements for interface strategy

### DIFF
--- a/tests/_introspect.py
+++ b/tests/_introspect.py
@@ -155,16 +155,23 @@ def arg_strategy():
                   }), sets(annotation_strategy()))
 
 
-def interface_strategy():
+def interface_strategy(*, min_children=None, max_children=None):
     """
     Build a strategy to generate data for an introspection interface.
+
+    :param min_children: the minimum number of child elements in this interface
+    :type min_children: non-negative int or None
+    :param max_children: the maximum number of child elements in this interface
+    :type max_children: non-negative int or None
     """
     return builds(Interface, fixed_dictionaries({
         'name': _TEXT_STRATEGY,
     }),
                   sets(
                       one_of(property_strategy(), method_strategy(),
-                             annotation_strategy(), signal_strategy())))
+                             annotation_strategy(), signal_strategy()),
+                      min_size=min_children,
+                      max_size=max_children))
 
 
 def method_strategy():

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -22,7 +22,7 @@ class TestCase(unittest.TestCase):
     Test the behavior of various auto-generated classes
     """
 
-    @given(interface_strategy().map(lambda x: x.element()))
+    @given(interface_strategy(max_children=30).map(lambda x: x.element()))
     def test_managed_object(self, spec):
         """
         Test that the GMO object has the correct set of methods.
@@ -57,7 +57,7 @@ class TestCase(unittest.TestCase):
             with self.assertRaises(DbusClientMissingPropertyError):
                 getattr(obj, remove_name)()
 
-    @given(interface_strategy().map(lambda x: x.element()))
+    @given(interface_strategy(max_children=30).map(lambda x: x.element()))
     def test_managed_object_query(self, spec):
         """
         Test that the query returns appropriate values for its query input.


### PR DESCRIPTION
If no cap is set, Hypothesis can occasionally make really big ones,
which may fail the Hypothesis health check because they take so long
to compute.

Signed-off-by: mulhern <amulhern@redhat.com>