### PR TITLE
Omit an else

### DIFF
--- a/src/dbus_client_gen/_managed_objects_queries.py
+++ b/src/dbus_client_gen/_managed_objects_queries.py
@@ -86,8 +86,7 @@ class GMOQuery():
                     "No unique match found for interface %s and properties %s, found %s"
                     % (self._interface_name, self._props, list_result),
                     self._interface_name, self._props, list_result)
-            else:
-                result = (x for x in list_result)
+            result = (x for x in list_result)
 
         return result
 


### PR DESCRIPTION
To avoid pylint error no-else-raise.

Signed-off-by: mulhern <amulhern@redhat.com>