### PR TITLE
Increase CURRENT DEVELOPMENT ENVIRONMENT to Fedora 42

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,12 @@ jobs:
             task: make -f Makefile fmt-travis
           - dependencies: yamllint
             task: make -f Makefile yamllint
-          - dependencies: bandit pylint python3-hypothesis python3-setuptools
+          - dependencies: >
+              bandit
+              libatomic
+              pylint
+              python3-hypothesis
+              python3-setuptools
             task: >
               PATH=${PATH}:/github/home/.local/bin
               PYTHONPATH=./src:/github/home/.local/lib/python3.13/site-packages
@@ -30,7 +35,7 @@ jobs:
           - dependencies: python3-coverage python3-hypothesis python3-setuptools
             task: PYTHONPATH=./src make -f Makefile coverage
     runs-on: ubuntu-latest
-    container: fedora:41  # CURRENT DEVELOPMENT ENVIRONMENT
+    container: fedora:42  # CURRENT DEVELOPMENT ENVIRONMENT
     steps:
       - uses: actions/checkout@v5
         with:
@@ -55,7 +60,7 @@ jobs:
           - dependencies: python3-hypothesis
             task: PYTHONPATH=./src make -f Makefile test
     runs-on: ubuntu-latest
-    container: fedora:41  # CURRENT DEVELOPMENT ENVIRONMENT
+    container: fedora:42  # CURRENT DEVELOPMENT ENVIRONMENT
     steps:
       - name: Install python3.12
         run: >

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
   monkeytype:
     runs-on: ubuntu-24.04
     container:
-      image: fedora:41  # CURRENT DEVELOPMENT ENVIRONMENT
+      image: fedora:42  # CURRENT DEVELOPMENT ENVIRONMENT
     steps:
       - name: Install dependencies for Fedora
         run: >

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
+python_requires = >=3.12
 package_dir =
     = src
 


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development and CI base images from Fedora 41 to Fedora 42.
  * Set minimum supported Python version to 3.12.
  * Reformatted development dependency declarations in CI configuration to a multiline list for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->